### PR TITLE
Update Go to 1.25.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.6'
+          go-version: '1.25.7'
           cache: true
 
       - name: Install Trivy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6 AS build
+FROM golang:1.25.7 AS build
 COPY . /workspace
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -mod=vendor -ldflags "-s" -a -installsuffix cgo -o /main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bborbe/backup
 
-go 1.25.6
+go 1.25.7
 
 exclude (
 	cloud.google.com/go v0.26.0


### PR DESCRIPTION
Updates Go version to 1.25.7:
- go.mod
- Dockerfile  
- CI workflow

🦀 OpenClaw