### PR TITLE
Update Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bborbe/backup
 
-go 1.25.7
+go 1.26.0
 
 exclude (
 	cloud.google.com/go v0.26.0


### PR DESCRIPTION
Update Go version to 1.26.0

## Verification
- `go test ./...` ✅
- `govulncheck` ✅
- `osv-scanner` ✅
- `gosec` ✅
- `trivy` ✅