### PR TITLE
fix(deps): bump Go toolchain to 1.26.5 (GO-2026-5856 stdlib vuln)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- fix(deps): bump Go toolchain to 1.26.5 (GO-2026-5856 stdlib vuln)
+
 ## v3.9.22
 
 - Bump Go module dependencies (bborbe/*, k8s.io/*, ginkgo, gomega, etc.)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 AS build
+FROM golang:1.26.5 AS build
 COPY . /workspace
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -mod=vendor -ldflags "-s" -a -installsuffix cgo -o /main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bborbe/backup
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/bborbe/collection v1.20.17


### PR DESCRIPTION
Bumps the Go toolchain 1.26.4 → 1.26.5 to clear stdlib vuln **GO-2026-5856** (osv-scanner finding). x/text was already at v0.40.0; this was the remaining gate failure that parked the Update-Go task.

- `go.mod`: go 1.26.4 → 1.26.5
- `Dockerfile`: golang:1.26.4 → 1.26.5
- `make check` now green (vet + govulncheck + osv-scanner + trivy all clean)

Unblocks [[Update Go bborbe-backup b49d935]].